### PR TITLE
Feat/support npm install from git repos

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Run tests and collect coverage
         run: pnpm run test::coverage
 
-      - name: Build
-        run: pnpm run build
-
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
@@ -56,6 +53,6 @@ jobs:
       - name: Publish Package to NPM
         uses: JS-DevTools/npm-publish@v2
         with:
-          token: ${{secrets.npm_token}}
+          token: ${{secrets.NPM_TOKEN}}
           provenance: true
           tag: latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm-rollup-ts-template",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "dist/index.cjs",
   "umd": "dist/index.umd.js",
@@ -32,7 +32,9 @@
     "template"
   ],
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "author": "ishiko",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "rollup -c rollup.config.ts --configPlugin esbuild -w",
     "test": "pnpm run lint && jest --config=jest.config.ts --passWithNoTests",
     "test::coverage": "jest --coverage --config=jest.config.ts",
+    "prepare": "npm run build",
     "build::clean": "rimraf ./dist",
     "build::proc": "rollup -c rollup.config.ts --configPlugin esbuild",
     "build::types": "pnpm build::clean && tsc --project ./tsconfig.json --declaration true",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "typescript",
     "template"
   ],
+  "files": [
+    "dist"
+  ],
   "author": "ishiko",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
use:
```bash
pnpm install github:ishiko732/pnpm-ts-rollup-template#Feat/support-npm-install-git-repos 
```
ref:
- https://docs.npmjs.com/cli/v11/using-npm/scripts
- https://stackoverflow.com/questions/48287776/automatically-build-npm-module-on-install-from-github/57503862#57503862